### PR TITLE
Add anchors to nav buttons

### DIFF
--- a/src/Components/Icons.elm
+++ b/src/Components/Icons.elm
@@ -1,5 +1,6 @@
 module Components.Icons exposing (left, right)
 
+import Html exposing (a)
 import Svg exposing (Svg, path, svg)
 import Svg.Attributes exposing (class, viewBox, height, fill, d)
 import Svg.Events exposing (onClick)
@@ -17,12 +18,14 @@ right =
 
 icon : String -> String -> Int -> msg -> Svg msg
 icon pathString className h onClickMsg =
-    svg
-        [ class className
-        , viewBox "0 0 24 24"
-        , height (toString h)
-        , fill "currentColor"
-        , onClick onClickMsg
-        ]
-        [ path [ d pathString ] []
+    a [ onClick onClickMsg ]
+        [ svg
+            [ class className
+            , viewBox "0 0 24 24"
+            , height (toString h)
+            , fill "currentColor"
+            , onClick onClickMsg
+            ]
+            [ path [ d pathString ] []
+            ]
         ]


### PR DESCRIPTION
Hey!
I'm kinda learning Elm, and was reading your newsletter.
I use Vimium which enables keyboard based browsing, and I hadn't been able to use navigation buttons. So, adding anchors should help for every keyboard-user. 

But maybe there's better way than adding anchors, like adding something to svg tag, I'm not sure.