### PR TITLE
Changing size of github footer icon

### DIFF
--- a/main.css
+++ b/main.css
@@ -237,6 +237,10 @@ a {
   color: #FFFFFF;
 }
 
+.footer__github {
+  height: 32px;
+}
+
 .error {
   position: fixed;
   right: 12px;


### PR DESCRIPTION
Due to the changed icon, the github logo in the footer is a too large. Made this small adjustment. After this is merged, the issue should be done :)

Solves #11 