### PR TITLE
Unescape titles

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -17,6 +17,7 @@
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",
         "elm-lang/window": "1.0.1 <= v < 2.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
+        "marcosh/elm-html-to-unicode": "1.0.2 <= v < 2.0.0",
         "mgold/elm-date-format": "1.1.7 <= v < 2.0.0",
         "sporto/erl": "10.0.2 <= v < 11.0.0"
     },

--- a/src/News/News.elm
+++ b/src/News/News.elm
@@ -10,10 +10,10 @@ module News.News
         )
 
 import Date exposing (Date)
+import ElmEscapeHtml exposing (unescape)
 import Html exposing (Html, div, a, text, span)
-import Html.Attributes exposing (class, classList, href, id, property)
+import Html.Attributes exposing (class, classList, href, id)
 import Html.Events exposing (onClick)
-import Json.Encode exposing (string)
 import Analytics exposing (Event, NewsEventInfo)
 import News.Tag as Tag
 import DateFormatter
@@ -152,9 +152,8 @@ linkView story =
             [ onClick (ClickStory story)
             , href story.url
             , class "card__description__title"
-            , property  "innerHTML" <| string story.title
             ]
-            [ ]
+            [ text <| unescape story.title]
         , span [ class "card__description__domain" ]
             [ text <| "(" ++ (Url.domain story.url) ++ ")" ]
         ]


### PR DESCRIPTION
Avoids using `innerHtml` (security).  Wasn't too easy, because I've no elm 0.18 setup anymore. Please have a second look. Thanks.

Relates to #18